### PR TITLE
Support for mocha reporters on the client.

### DIFF
--- a/browser-shim.js
+++ b/browser-shim.js
@@ -1,0 +1,154 @@
+/**
+ * Sourced from: https://github.com/nathanboktae/mocha-phantomjs-core
+ */
+(function(){
+
+    // A shim for non ES5 supporting browsers, like PhantomJS. Lovingly inspired by:
+    // http://www.angrycoding.com/2011/09/to-bind-or-not-to-bind-that-is-in.html
+    if (!('bind' in Function.prototype)) {
+        Function.prototype.bind = function() {
+            var funcObj = this;
+            var extraArgs = Array.prototype.slice.call(arguments);
+            var thisObj = extraArgs.shift();
+            return function() {
+                return funcObj.apply(thisObj, extraArgs.concat(Array.prototype.slice.call(arguments)));
+            };
+        };
+    }
+
+    function isFileReady(readyState) {
+        // Check to see if any of the ways a file can be ready are available as properties on the file's element
+        return (!readyState || readyState == 'loaded' || readyState == 'complete' || readyState == 'uninitialized')
+    }
+
+    function shimMochaProcess(M) {
+        // Mocha needs a process.stdout.write in order to change the cursor position.
+        M.process = M.process || {}
+        M.process.stdout = M.process.stdout || process.stdout
+        M.process.stdout.write = function(s) { window.callPhantom({ stdout: s }) }
+        window.callPhantom({ getColWith: true })
+    }
+
+    function shimMochaInstance(m) {
+        var origRun = m.run, origUi = m.ui
+        m.ui = function() {
+            var retval = origUi.apply(mocha, arguments)
+            window.callPhantom({ configureMocha: true })
+            m.reporter = function() {}
+            return retval
+        }
+        m.run = function() {
+            window.callPhantom({ testRunStarted: m.suite.suites.length })
+            m.runner = origRun.apply(mocha, arguments)
+            if (m.runner.stats && m.runner.stats.end) {
+                window.callPhantom({ testRunEnded: m.runner })
+            } else {
+                m.runner.on('end', function() {
+                    window.callPhantom({ testRunEnded: m.runner })
+                })
+            }
+            return m.runner
+        }
+    }
+
+    Object.defineProperty(window, 'checkForMocha', {
+        value: function() {
+            var scriptTags = document.querySelectorAll('script'),
+                mochaScript = Array.prototype.filter.call(scriptTags, function(s) {
+                    var src = s.getAttribute('src')
+                    return src && src.match(/mocha\.js$/)
+                })[0]
+
+            if (mochaScript) {
+                mochaScript.onreadystatechange = mochaScript.onload = function () {
+                    if (isFileReady(mochaScript.readyState)) {
+                        initMochaPhantomJS()
+                    }
+                }
+            }
+        }
+    })
+
+    if ('mozInnerScreenX' in window) {
+        // in slimerjs, we can stub out a setter to shim Mocha. phantomjs 2 fails
+        // to allow the property to be reconfigured...
+        Object.defineProperty(window, 'mocha', {
+            get: function() { return undefined },
+            set: function(m) {
+                shimMochaInstance(m)
+                delete window.mocha
+                window.mocha = m
+            },
+            configurable: true
+        })
+
+        Object.defineProperty(window, 'Mocha', {
+            get: function() { return undefined },
+            set: function(m) {
+                delete window.Mocha
+                window.Mocha = m
+                shimMochaProcess(m)
+            },
+            configurable: true
+        })
+    } else {
+        Object.defineProperty(window, 'initMochaPhantomJS', {
+            value: function () {
+                shimMochaProcess(Mocha)
+                shimMochaInstance(mocha)
+                delete window.initMochaPhantomJS
+            },
+            configurable: true
+        })
+    }
+
+    // Mocha needs the formating feature of console.log so copy node's format function and
+    // monkey-patch it into place. This code is copied from node's, links copyright applies.
+    // https://github.com/joyent/node/blob/master/lib/util.js
+    if (!console.format) {
+        console.format = function(f) {
+            if (typeof f !== 'string') {
+                return Array.prototype.map.call(arguments, function(arg) {
+                    try {
+                        return JSON.stringify(arg)
+                    }
+                    catch (_) {
+                        return '[Circular]'
+                    }
+                }).join(' ')
+            }
+            var i = 1;
+            var args = arguments;
+            var len = args.length;
+            var str = String(f).replace(/%[sdj%]/g, function(x) {
+                if (x === '%%') return '%';
+                if (i >= len) return x;
+                switch (x) {
+                    case '%s': return String(args[i++]);
+                    case '%d': return Number(args[i++]);
+                    case '%j':
+                        try {
+                            return JSON.stringify(args[i++]);
+                        } catch (_) {
+                            return '[Circular]';
+                        }
+                    default:
+                        return x;
+                }
+            });
+            for (var x = args[i]; i < len; x = args[++i]) {
+                if (x === null || typeof x !== 'object') {
+                    str += ' ' + x;
+                } else {
+                    str += ' ' + JSON.stringify(x);
+                }
+            }
+            return str;
+        };
+        var origError = console.error;
+        console.error = function(){ origError.call(console, console.format.apply(console, arguments)); };
+        var origLog = console.log;
+        console.log = function(){ origLog.call(console, console.format.apply(console, arguments)); };
+    }
+
+})();

--- a/client.js
+++ b/client.js
@@ -1,4 +1,4 @@
-import browserConsoleReporter from './browserConsoleReporter';
+import './browser-shim.js';
 
 // Run the client tests. Meteor calls the `runTests` function exported by
 // the driver package on the client.
@@ -7,9 +7,7 @@ function runTests() {
   // correct reporter is used in the case where `dispatch:mocha` is also
   // added to the app. Since both are testOnly packages, top-level client code in both
   // will run, potentially changing the reporter to the console reporter.
-  mocha.setup({
-    reporter: browserConsoleReporter,
-  });
+  mocha.reporter(Meteor.settings.public.env.CLIENT_TEST_REPORTER || 'spec');
 
   // These `window` properties are all used by the phantomjs script to
   // know what is happening.

--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@ Package.describe({
   summary: "Run package or app tests with Mocha+PhantomJS and report all results in the server console",
   git: "https://github.com/DispatchMe/meteor-mocha-phantomjs.git",
   version: '0.0.8',
-  testOnly: true,
+  testOnly: true
 });
 
 Package.onUse(function (api) {
@@ -11,11 +11,11 @@ Package.onUse(function (api) {
 
   api.use([
     'dispatch:mocha-core@0.0.1',
-    'ecmascript',
+    'ecmascript'
   ]);
 
   api.use([
-    'dispatch:phantomjs-tests@0.0.4',
+    'dispatch:phantomjs-tests@0.0.4'
   ], 'server');
 
   api.mainModule('client.js', 'client');

--- a/server.js
+++ b/server.js
@@ -17,7 +17,8 @@ let serverTestsDone = false;
 let clientLines = [];
 function clientLogBuffer(line) {
   if (serverTestsDone) {
-    console.log(line);
+    // printing and removing the extra new-line character. The first was added by the client log, the second here.
+    console.log(line.replace(/\n$/, ''));
   } else {
     clientLines.push(line);
   }
@@ -41,7 +42,8 @@ function exitIfDone(type, failures) {
     serverTestsDone = true;
     printHeader('CLIENT');
     clientLines.forEach((line) => {
-      console.log(line);
+      // printing and removing the extra new-line character. The first was added by the client log, the second here.
+      console.log(line.replace(/\n$/, ''));
     });
   }
 

--- a/server.js
+++ b/server.js
@@ -3,6 +3,12 @@ import { startPhantom } from 'meteor/dispatch:phantomjs-tests';
 
 const reporter = process.env.SERVER_TEST_REPORTER || 'spec';
 
+// pass the current env settings to the client.
+Meteor.startup(function() {
+  Meteor.settings.public = Meteor.settings.public || {};
+  Meteor.settings.public.env = process.env;
+});
+
 // Since intermingling client and server log lines would be confusing,
 // the idea here is to buffer all client logs until server tests have
 // finished running and then dump the buffer to the screen and continue


### PR DESCRIPTION
Adds support for specifying the mocha reporter for the client via CLIENT_TEST_REPORTER. 
closes #5

There are some catches. Reporters that use streams can have issues. Like sending of backspace characters or progressive streams of dots. Confirmed this functionality works with the mocha tap and spec reporters.

 