### PR TITLE
Some meteor modules may not shutdown correctly with process.exit()

### DIFF
--- a/server.js
+++ b/server.js
@@ -55,10 +55,13 @@ function exitIfDone(type, failures) {
     console.log('--------------------------------');
     if (!process.env.TEST_WATCH) {
       if (clientFailures + serverFailures > 0) {
-        process.exit(2); // exit with non-zero status if there were failures
+        process.exitCode=2; // exit with non-zero status if there were failures
       } else {
-        process.exit(0);
+        process.exitCode=0;
       }
+      //allow meteor process to handle the SIGINT status and shutdown
+      //gracefully instead of using process.exit();
+      process.kill(process.pid, 'SIGINT');
     }
   }
 }


### PR DESCRIPTION
When using process.exit(), some meteor modules may fail to shutdown
properly. Use process.kill instead to allow meteor to shutdown itself
and set exitCode accordingly using process.exitCode.

Change-Id: I86b6bd141c9d4ac1fe0c58e074c08c696e1ffe09
